### PR TITLE
Fix typo in test predicate

### DIFF
--- a/code/src/test/scala/introduction/01-list-suite.scala
+++ b/code/src/test/scala/introduction/01-list-suite.scala
@@ -29,7 +29,7 @@ class StreamAsListSuite extends FunSuite {
 
   test("only") {
     assertEquals(StreamAsList.only(Stream(1, 2, 3, 4, 5, 6, 7, 8, 9), _ % 2 == 0).toList, List(2, 4, 6, 8))
-    assertEquals(StreamAsList.only(Stream(1, 2, 3, 4, 5, 6, 7, 8, 9), _ < 5 == 0).toList, List(1, 2, 3, 4))
+    assertEquals(StreamAsList.only(Stream(1, 2, 3, 4, 5, 6, 7, 8, 9), _ < 5).toList, List(1, 2, 3, 4))
   }
 
   test("sum") {


### PR DESCRIPTION
Thanks for the work that has gone in to this tutorial so far. 

I noticed a typo in the 'less than five' predicate in the list suite